### PR TITLE
simplify lambda permission source arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_lambda_permission" "apigw_lambda" {
   function_name = aws_lambda_function.lambda.function_name
   principal = "apigateway.amazonaws.com"
 
-  source_arn = "arn:aws:execute-api:us-west-2:${var.account-id}:${aws_api_gateway_rest_api.api.id}/*"
+  source_arn = aws_api_gateway_rest_api.api.execution_arn
 }
 
 resource "aws_api_gateway_domain_name" "api_domain" {


### PR DESCRIPTION
Simplify lambda permission source arn and make flexible for multi regions.

This should behave exactly like what you already had except now there is less hard coded.