### PR TITLE
fix api gateway to lambda permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_lambda_permission" "apigw_lambda" {
   action = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda.function_name
   principal = "apigateway.amazonaws.com"
-  source_arn = aws_api_gateway_rest_api.api.execution_arn
+  source_arn = "${aws_api_gateway_rest_api.api.execution_arn}/*"
   depends_on    = [aws_iam_role_policy_attachment.lambda_logs, aws_cloudwatch_log_group.logs]
 }
 


### PR DESCRIPTION
Fixes the permissions that allow API Gateway to invoke the Lambda. Before merging this, you should test with `?ref=fix-permissions`. If that works, you should move the `v1.0.5` tag to this commit, as that tag is currently broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/byu-oit/terraform-aws-mobile-gateway-lambda/4)
<!-- Reviewable:end -->
